### PR TITLE
Adding support for absolute paths on windows

### DIFF
--- a/lib/pact/provider_verifier/app.rb
+++ b/lib/pact/provider_verifier/app.rb
@@ -88,7 +88,7 @@ end
 
 def get_json(path)
   case path
-  when URI::regexp
+  when URI::regexp(%w(http https))
     return get_json_from_server(path)
   else
     return get_json_from_local_file(path)


### PR DESCRIPTION
When supplying an absolute pact file path like C:\pacts\my-pact-file.json, the code would detect this as a broker url. To resolve this I have added a http/https scheme check expression.