### PR TITLE
Add provider_header option

### DIFF
--- a/lib/pact/provider_verifier/app.rb
+++ b/lib/pact/provider_verifier/app.rb
@@ -34,6 +34,7 @@ module Pact
         ENV['PROVIDER_STATES_SETUP_URL'] = @options.provider_states_setup_url
         ENV['VERBOSE_LOGGING'] = @options.verbose if @options.verbose
         provider_base_url = @options.provider_base_url
+        provider_header = @options.provider_header
 
         provider_application_version = @options.provider_app_version
         publish_results  = @options.publish_verification_results

--- a/lib/pact/provider_verifier/app.rb
+++ b/lib/pact/provider_verifier/app.rb
@@ -34,7 +34,6 @@ module Pact
         ENV['PROVIDER_STATES_SETUP_URL'] = @options.provider_states_setup_url
         ENV['VERBOSE_LOGGING'] = @options.verbose if @options.verbose
         provider_base_url = @options.provider_base_url
-        provider_header = @options.provider_header
 
         provider_application_version = @options.provider_app_version
         publish_results  = @options.publish_verification_results

--- a/lib/pact/provider_verifier/cli.rb
+++ b/lib/pact/provider_verifier/cli.rb
@@ -14,6 +14,7 @@ module Pact
       method_option :broker_username, aliases: "-n", desc: "Pact Broker username", :required => false
       method_option :broker_password, aliases: "-p", desc: "Pact Broker password", :required => false
       method_option :verbose, aliases: "-v", desc: "Verbose output", :required => false
+      method_option :provider_header, aliases: "-provider_header", desc: "Provider header", :required => false
       method_option :provider_states_url, aliases: "-s", desc: "DEPRECATED", :required => false
 
       def verify

--- a/lib/pact/provider_verifier/set_up_provider_state.rb
+++ b/lib/pact/provider_verifier/set_up_provider_state.rb
@@ -35,6 +35,11 @@ module Pact
       def post_to_provider_state
         connection = Faraday.new(:url => provider_states_setup_url)
         connection.post do |req|
+          if (@options.has_key?(:provider_header)) 
+            header = @options[:provider_header].split(":")
+            req.headers[header[0]] = header[1]
+          end 
+
           req.headers["Content-Type"] = "application/json"
           req.body = {consumer: consumer, state: provider_state, states: [provider_state] }.to_json
         end

--- a/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
+++ b/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
@@ -25,6 +25,19 @@ module Pact
           with(body: {consumer: consumer, state: provider_state, states: [provider_state]}, headers: {'Content-Type' => "application/json"})
       end
 
+      context "sending a provider header" do
+        let(:options) {{:header_provider => "Authorization:Basic dGVzdGU6dGVzdGU="}}
+
+          it "makes a HTTP request with a provider header" do
+            
+            subject
+
+            expect(WebMock).to have_requested(:post, provider_states_setup_url).
+              with(body: {consumer: consumer, state: provider_state, states: [provider_state]}, headers: {'Autorization' => "Basic dGVzdGU6dGVzdGU=", 'Content-Type' => "application/json"})
+          end
+        end
+
+
       context "when an error is returned from the request to the setup URL" do
         before do
           stub_request(:post, provider_states_setup_url).to_return(status: 500, body: "Some error")

--- a/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
+++ b/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
@@ -33,7 +33,7 @@ module Pact
             subject
 
             expect(WebMock).to have_requested(:post, provider_states_setup_url).
-              with(body: {consumer: consumer, state: provider_state, states: [provider_state]}, headers: {'Autorization' => "Basic dGVzdGU6dGVzdGU=", 'Content-Type' => "application/json"})
+              with(body: {consumer: consumer, state: provider_state, states: [provider_state]}, headers: {'Authorization' => "Basic dGVzdGU6dGVzdGU=", 'Content-Type' => "application/json"})
           end
         end
 

--- a/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
+++ b/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
@@ -26,7 +26,7 @@ module Pact
       end
 
       context "sending a provider header" do
-        let(:options) {{:header_provider => "Authorization:Basic dGVzdGU6dGVzdGU="}}
+        let(:options) {{:provider_header => "Authorization:Basic dGVzdGU6dGVzdGU="}}
 
           it "makes a HTTP request with a provider header" do
             


### PR DESCRIPTION
This PR adds a provider_header option (not required), which can be useful if you need to send a specific header to the provider e.g. an auth token.

It tries to solve this issue: https://github.com/SEEK-Jobs/pact-net/issues/104