### PR TITLE
fix: Provider verification fails when no pacts are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Options:
           # The log level
 
           # Default: debug
+      [--fail-if-no-pacts-found]
+          # If specified, will fail when no pacts are found
 
 Description:
   The parameters used when fetching pacts dynamically from a Pact Broker are:

--- a/lib/pact/provider_verifier/cli/verify.rb
+++ b/lib/pact/provider_verifier/cli/verify.rb
@@ -38,6 +38,7 @@ module Pact
         method_option :wait, banner: "SECONDS", required: false, type: :numeric, desc: "The number of seconds to poll for the provider to become available before running the verification", default: 0
         method_option :log_dir, desc: "The directory for the pact.log file"
         method_option :log_level, desc: "The log level", default: "debug"
+        method_option :fail_if_no_pacts_found, desc: "If specified, will fail when no pacts are found", required: false, type: :boolean, default: false
 
         def verify(*pact_urls)
           require 'pact/provider_verifier/app'

--- a/spec/lib/pact/provider_verifier/app_spec.rb
+++ b/spec/lib/pact/provider_verifier/app_spec.rb
@@ -94,6 +94,23 @@ module Pact
             it { is_expected.to be true }
           end
         end
+
+        context "multiple pacts need to be verified" do
+          before do
+            allow(AggregatePactConfigs).to receive(:call).and_return([{}, {}])
+          end
+
+          context "at least one pact fails verification" do
+            before do
+              allow(Cli::RunPactVerification).to receive(:call).and_return(1)
+            end
+
+            it "all pacts get verified" do
+              expect(Cli::RunPactVerification).to receive(:call).twice
+              subject
+            end
+          end
+        end
       end
     end
   end

--- a/spec/lib/pact/provider_verifier/app_spec.rb
+++ b/spec/lib/pact/provider_verifier/app_spec.rb
@@ -24,6 +24,7 @@ module Pact
           double('options',
             provider_base_url: "http://provider",
             provider_version_tag: ["foo"],
+            publish_verification_results: false,
             wait: 1,
             provider_states_url: nil,
             log_level: :info,
@@ -54,6 +55,43 @@ module Pact
               anything
             )
             subject
+          end
+        end
+
+        context "when fail_if_no_pacts_found is false" do
+          before do
+            allow(options).to receive(:fail_if_no_pacts_found).and_return(false)
+          end
+
+          context "when no pacts are found" do
+            before do
+              allow(AggregatePactConfigs).to receive(:call).and_return([])
+            end
+
+            it { is_expected.to be true }
+          end
+        end
+
+        context "when fail_if_no_pacts_found is true" do
+          before do
+            allow(options).to receive(:fail_if_no_pacts_found).and_return(true)
+          end
+
+          context "when no pacts are found" do
+            before do
+              allow(AggregatePactConfigs).to receive(:call).and_return([])
+            end
+
+            it { is_expected.to be false }
+          end
+
+          context "when pacts are found and successfully verified" do
+            before do
+              allow(AggregatePactConfigs).to receive(:call).and_return([{}])
+              allow(Cli::RunPactVerification).to receive(:call).and_return(0)
+            end
+
+            it { is_expected.to be true }
           end
         end
       end


### PR DESCRIPTION
I recently implemented Pact in one of my JS services. While doing so, I was surprised to find that my jest tests were passing, even though there were no pacts in my broker that matched the `consumerVersionSelectors` specified in the test.

On one hand, I can see why this behavior might be desired, as it is true that the provider verification did not fail against any pacts that were specified.

On the other hand, my expectation when verifying a provider is that there is a matching pact to verify against. If the provider passes when no pact is present, I might mistakenly think that it passed against a valid pact. As a newcomer to Pact, it seems like this scenario should fail