### PR TITLE
feat: Use load for monkeypatch instead of require

### DIFF
--- a/lib/pact/provider_verifier/pact_helper.rb
+++ b/lib/pact/provider_verifier/pact_helper.rb
@@ -15,9 +15,9 @@ end
 
 if ENV['MONKEYPATCH']
   ENV['MONKEYPATCH'].split("\n").each do | file |
-    $stdout.puts "DEBUG: Requiring monkeypatch file #{file}" if ENV['VERBOSE_LOGGING']
+    $stdout.puts "DEBUG: Loading monkeypatch file #{file}" if ENV['VERBOSE_LOGGING']
     begin
-      require file
+      load(file)
     rescue LoadError => e
       $stderr.puts "ERROR: #{e.class} - #{e.message}. Ensure you have specified the absolute path."
     end

--- a/spec/integration_with_monkeypatch_spec.rb
+++ b/spec/integration_with_monkeypatch_spec.rb
@@ -4,19 +4,38 @@ describe "pact-provider-verifier with monkeypatch" do
     sleep 2
   end
 
-  subject { `bundle exec bin/pact-provider-verifier ./test/me-they.json --monkeypatch #{Dir.pwd}/spec/support/monkeypatch.rb --monkeypatch #{Dir.pwd}/spec/support/another_monkeypatch.rb -a 1.0.100 --provider-base-url http://localhost:4870 --provider_states_setup_url http://localhost:4870/provider-state 2>&1` }
+  let(:env) { 'VERBOSE_LOGGING=true' }
+  subject { `#{env} bundle exec bin/pact-provider-verifier ./test/me-they.json #{monkey_patch_args} -a 1.0.100 --provider-base-url http://localhost:4870 --provider_states_setup_url http://localhost:4870/provider-state 2>&1` }
 
-  it "exits with a 0 exit code" do
-    subject
-    puts subject
-    expect($?).to eq 0
+  describe 'loading two different monkey patches' do
+    let(:monkey_patch_args) { "--monkeypatch #{Dir.pwd}/spec/support/monkeypatch.rb --monkeypatch #{Dir.pwd}/spec/support/another_monkeypatch.rb" }
+
+    it "exits with a 0 exit code" do
+      subject
+      puts subject
+      expect($?).to eq 0
+    end
+
+    it "loads the monkeypatch file" do
+      expect(subject).to include("THIS IS A MONKEYPATCHING FILE!!!")
+      expect(subject).to include("THIS IS ANOTHER MONKEYPATCHING FILE!!!")
+    end
   end
 
-  it "loads the monkeypatch file" do
-    expect(subject).to include "THIS IS A MONKEYPATCHING FILE!!!"
-    expect(subject).to include "THIS IS ANOTHER MONKEYPATCHING FILE!!!"
-  end
+  describe 'loading same monkey' do
+    let(:monkey_patch_args) { "--monkeypatch #{Dir.pwd}/spec/support/monkeypatch.rb --monkeypatch #{Dir.pwd}/spec/support/monkeypatch.rb" }
 
+    it "exits with a 0 exit code" do
+      subject
+      puts subject
+      expect($?).to eq 0
+    end
+
+    it "loads the monkeypatch file twice" do
+      expect(subject).to include("THIS IS A MONKEYPATCHING FILE!!!").twice
+      expect(subject).to include("DEBUG: Loading monkeypatch file").twice
+    end
+  end
 
   after(:all) do
     Process.kill 'KILL', @pipe.pid


### PR DESCRIPTION
I've noticed that, during provider verification, if I have more than one pact file to verify, monkey changes are applied just for the first verification. I'm adding extra config params to `Pact.configure` and `Rspec.configure`, which are being cleared up on each pact file verification.

Even if theoretically it could be breaking change, @bethesque suggested to changes require to load without any switch. Original PR https://github.com/pact-foundation/pact-provider-verifier/pull/68