### PR TITLE
fix: Return non-error if enable-pending is set

### DIFF
--- a/lib/pact/provider_verifier/set_up_provider_state.rb
+++ b/lib/pact/provider_verifier/set_up_provider_state.rb
@@ -91,9 +91,13 @@ module Pact
       end
 
       def check_for_error response
-        if response.status >= 300
-          raise SetUpProviderStateError.new("Error setting up provider state '#{provider_state}' for consumer '#{consumer}' at #{provider_states_setup_url}. response status=#{response.status} response body=#{response.body}")
+        if response.status >= 300 && !(@options[:enable_pending] == true)
+          raise SetUpProviderStateError.new(set_up_provider_state_error_message(response))
         end
+      end
+
+      def set_up_provider_state_error_message(response)
+        "Error setting up provider state '#{provider_state}' for consumer '#{consumer}' at #{provider_states_setup_url}. response status=#{response.status} response body=#{response.body}"
       end
 
       def log_request

--- a/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
+++ b/spec/lib/pact/provider_verifier/set_up_provider_state_spec.rb
@@ -31,8 +31,23 @@ module Pact
           stub_request(:post, provider_states_setup_url).to_return(status: 500, body: "Some error")
         end
 
-        it "raises an error" do
-          expect { subject }.to raise_error(SetUpProviderStateError, /500.*Some error/)
+        context "when enable_pending is not set" do
+          it "raises an error" do
+            expect { subject }.to raise_error(SetUpProviderStateError, /500.*Some error/)
+          end
+        end
+
+        context "when enable_pending is set" do
+          let(:options) do
+            {
+              params: params,
+              enable_pending: true,
+            }
+          end
+
+          it "does not raise an error" do
+            expect { subject }.not_to raise_error
+          end
         end
       end
 


### PR DESCRIPTION
Hi @bethesque 

I created the PR to start the conversation on the solution to fix https://github.com/pact-foundation/pact-provider-verifier/issues/121

Please have a look if the it is sound :P

I have not tested it yet. Will look at testing it later

Cheers
Bang

fixes #121 