### PR TITLE
chore: fix entry in release notes #34

### DIFF
--- a/packaging/RELEASE_NOTES.md.template
+++ b/packaging/RELEASE_NOTES.md.template
@@ -30,5 +30,5 @@ cd pact-provider-verifier-<PACKAGE_VERSION>-linux-x86/bin
 
 Download package, unzip, cd to pact-provider-verifier-<PACKAGE_VERSION>-win32 and then run:
 ```
-.\bin\pact-mock-service.bat -p 1234
+.\bin\pact-provider-verifier.bat -p 1234
 ```


### PR DESCRIPTION
Release notes are _not_ using the release note template so no download instructions - see linked issue #34 

build failures expected until #103 merged