### PR TITLE
Bump Faraday to 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby ">= 2.6"
+
 gemspec
 
 if ENV['X_PACT_DEVELOPMENT']

--- a/lib/pact/provider_verifier/app.rb
+++ b/lib/pact/provider_verifier/app.rb
@@ -9,7 +9,6 @@ require 'pact/cli/run_pact_verification'
 require 'pact/provider_verifier/aggregate_pact_configs'
 require 'pact/provider_verifier/git'
 require 'rack/reverse_proxy'
-require 'faraday_middleware'
 require 'json'
 
 module Pact

--- a/lib/pact/provider_verifier/pact_helper.rb
+++ b/lib/pact/provider_verifier/pact_helper.rb
@@ -1,5 +1,5 @@
 require 'net/https'
-require 'faraday_middleware'
+
 require 'json'
 require_relative './app'
 require_relative 'set_up_provider_state'

--- a/lib/pact/provider_verifier/set_up_provider_state.rb
+++ b/lib/pact/provider_verifier/set_up_provider_state.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday/retry'
 
 module Pact
   module ProviderVerifier

--- a/pact-provider-verifier.gemspec
+++ b/pact-provider-verifier.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pact', '~> 1.59'
   gem.add_runtime_dependency 'pact-message', '~>0.5'
   gem.add_runtime_dependency 'faraday', '~> 2.5'
-  gem.add_runtime_dependency 'faraday_middleware', '>= 0.10', '<= 2.0'
   gem.add_runtime_dependency 'json',  '>1.8'
   gem.add_runtime_dependency 'rack', '~> 2.1'
   gem.add_runtime_dependency 'rack-reverse-proxy'

--- a/pact-provider-verifier.gemspec
+++ b/pact-provider-verifier.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rspec', '~> 3.5'
   gem.add_runtime_dependency 'pact', '~> 1.59'
   gem.add_runtime_dependency 'pact-message', '~>0.5'
-  gem.add_runtime_dependency 'faraday', '>= 0.9.0', '<= 2.0'
+  gem.add_runtime_dependency 'faraday', '~> 2.5'
   gem.add_runtime_dependency 'faraday_middleware', '>= 0.10', '<= 2.0'
   gem.add_runtime_dependency 'json',  '>1.8'
   gem.add_runtime_dependency 'rack', '~> 2.1'

--- a/pact-provider-verifier.gemspec
+++ b/pact-provider-verifier.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pact', '~> 1.59'
   gem.add_runtime_dependency 'pact-message', '~>0.5'
   gem.add_runtime_dependency 'faraday', '~> 2.5'
+  gem.add_runtime_dependency 'faraday-retry'
   gem.add_runtime_dependency 'json',  '>1.8'
   gem.add_runtime_dependency 'rack', '~> 2.1'
   gem.add_runtime_dependency 'rack-reverse-proxy'

--- a/pact-provider-verifier.gemspec
+++ b/pact-provider-verifier.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pact', '~> 1.59'
   gem.add_runtime_dependency 'pact-message', '~>0.5'
   gem.add_runtime_dependency 'faraday', '~> 2.5'
-  gem.add_runtime_dependency 'faraday-retry'
+  gem.add_runtime_dependency 'faraday-retry', '~> 2.2'
   gem.add_runtime_dependency 'json',  '>1.8'
   gem.add_runtime_dependency 'rack', '~> 2.1'
   gem.add_runtime_dependency 'rack-reverse-proxy'


### PR DESCRIPTION
The purpose of this PR is to just upgrade Faraday from '>= 0.9.0', '<= 2.0' to '~> 2.5'.
In the process had to remove the deprecated gem 'faraday_middleware' and thus of removing this one, we've lost the retry one. To get back the retry one, we've added 'faraday-retry', this can be seen in 'lib/pact/provider_verifier/set_up_provider_state.rb' file.x